### PR TITLE
Fix: TypeError require is not a constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
 const crypto = require('crypto');
 const forge = require('node-forge');
 const {util: {binary: {base58}}} = forge;
-const ec = new require('elliptic').ec('secp256k1');
+const ec = new (require('elliptic')).ec('secp256k1');
 const util = require('./util');
 
 class Secp256k1KeyPair {


### PR DESCRIPTION
In certain environments calling require right after new causes a TypeError. This is easily fixable adding brackets around it.

Was using Jest when I came across this error, running as a node script with babel was fine.